### PR TITLE
Add some imports to package entry

### DIFF
--- a/zimply/__init__.py
+++ b/zimply/__init__.py
@@ -1,2 +1,15 @@
 __version__ = "1.0.7"
 
+from .zim_core import (ZIMClient, ZIMClientInvalidFile, ZIMClientNoFile,
+                       ZIMException, ZIMFile, ZIMFileIterator,
+                       ZIMFileUnpackError)
+
+__all__ = [
+    "ZIMClient",
+    "ZIMClientInvalidFile",
+    "ZIMClientNoFile",
+    "ZIMException",
+    "ZIMFile",
+    "ZIMFileIterator",
+    "ZIMFileUnpackError",
+]


### PR DESCRIPTION
Hi,

Thank you for maintaining this project. I plan to use it in [anki-wiktionary](https://github.com/abdnh/anki-wiktionary/)

The example code given in the README doesn't currently work because of a missing ZIMClient import in `__init__.py`.

I fixed that and added some additional imports for public symbols.